### PR TITLE
[RSDK-7236] setup GPIO and PWM pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ go.work
 # vscode files
 .vscode
 
+bin/
+
 # binary built from module
 viam-revolution-pi
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ go.work
 # vscode files
 .vscode
 
+# tool binaries
 bin/
 
 # binary built from module

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # viam-revolution-pi
 A modular component for Viam that adds support for the Revolution Pi PLC platform
+
+## setup
+
+Please follow the [Revolution Pi](https://revolutionpi.com/en/tutorials/quick-start-guide) setup documentation to configure your Revolution Pi. The majority of the configuration for a Revolution Pi occurs within [PiCtory](https://revolutionpi.com/en/tutorials/what-is-pictory).
+
+### GPIO and PWM
+
+The family of boards used for digital input and output are the [DIO modules](https://revolutionpi.com/en/tutorials/overview-revpi-io-modules). These have a set of GPIO pins to use with PWMs and counters. To configure an Output pin as a PWM pin, you must set the corresponding bit for that pin in the 'OutputPWMActive' Word in PiCtory. Because OutputPWMActive is stored in memory, you have to update the field in PiCtory, then update the Start-Config that the rev-pi uses and restart the board. The PWM frequency can also only be configured in PiCtory by updating the 'OutputPWMFrequency' field. Every PWM pin will use the same frequency.
+
+Interrupts and counters are not currently supported on the board
+
+#### example enabling a PWM pin
+
+If you want to enable pins O_3 and O_9 as a PWM pins, take the following steps
+
+ 1. first must update the 'OutputPWMActive' field in PiCtory
+    - The binary representation for enabling these two pins would be represented as 0b0000000100000100, with the decimal equivalent being 260
+ 2. Then you save your changes in PiCtory as the latest Start-Config
+ 3. Restart your Revolution Pi
+
+This will enable pins O_3 and O_9 as PWM pins, which can be used with Viam's APIs. This also means that O_3 and O_9 can no longer be used as normal GPIO pins.
+
+### ADC and DAC
+
+To have ADC and DAC you need an [AIO Module](https://revolutionpi.com/en/tutorials/overview-aio) attached to your Revolution Pi. ADC and DAC are currently not supported in this module.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Interrupts and counters are not currently supported on the board
 
 If you want to enable pins O_3 and O_9 as a PWM pins, take the following steps
 
- 1. first must update the 'OutputPWMActive' field in PiCtory
+ 1. First update the 'OutputPWMActive' field in PiCtory
     - The binary representation for enabling these two pins would be represented as 0b0000000100000100, with the decimal equivalent being 260
  2. Then you save your changes in PiCtory as the latest Start-Config
  3. Restart your Revolution Pi
@@ -24,4 +24,4 @@ This will enable pins O_3 and O_9 as PWM pins, which can be used with Viam's API
 
 ### ADC and DAC
 
-To have ADC and DAC you need an [AIO Module](https://revolutionpi.com/en/tutorials/overview-aio) attached to your Revolution Pi. ADC and DAC are currently not supported in this module.
+ADC and DAC are currently not supported in this module. See the [AIO Module](https://revolutionpi.com/en/tutorials/overview-aio) For more information on the Revolution Pi's capabilities.

--- a/module.go
+++ b/module.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
+	"viam-labs/viam-revolution-pi/revolution_pi"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
 	"go.viam.com/utils"
-	"viam-labs/viam-revolution-pi/revolution_pi"
 )
 
 func main() {
@@ -15,18 +15,18 @@ func main() {
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	custom_module, err := module.NewModuleFromArgs(ctx, logger)
+	customModule, err := module.NewModuleFromArgs(ctx, logger)
 	if err != nil {
 		return err
 	}
 
-	err = custom_module.AddModelFromRegistry(ctx, board.API, revolution_pi.Model)
+	err = customModule.AddModelFromRegistry(ctx, board.API, revolution_pi.Model)
 	if err != nil {
 		return err
 	}
 
-	err = custom_module.Start(ctx)
-	defer custom_module.Close(ctx)
+	err = customModule.Start(ctx)
+	defer customModule.Close(ctx)
 	if err != nil {
 		return err
 	}

--- a/module.go
+++ b/module.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
-	"viam-labs/viam-revolution-pi/revolution_pi"
 
 	"go.viam.com/rdk/components/board"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
 	"go.viam.com/utils"
+	"viam-labs/viam-revolution-pi/revolution_pi"
 )
 
 func main() {

--- a/revolution_pi/config.go
+++ b/revolution_pi/config.go
@@ -5,8 +5,10 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-var Model = resource.NewModel("viam-labs", "kunbus", "revolutionpi")
+// The model triplet for the rev-pi board.
+var Model = resource.NewModel("viam-labs", "kunbus", "revolution_pi")
 
+// The config for the rev-pi board.
 type Config struct {
 	resource.TriviallyValidateConfig
 	Attributes utils.AttributeMap `json:"attributes,omitempty"`

--- a/revolution_pi/config.go
+++ b/revolution_pi/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 // The model triplet for the rev-pi board.
-var Model = resource.NewModel("viam-labs", "kunbus", "revolution_pi")
+var Model = resource.NewModel("viam-labs", "kunbus", "revolutionpi")
 
 // The config for the rev-pi board.
 type Config struct {

--- a/revolution_pi/config.go
+++ b/revolution_pi/config.go
@@ -5,10 +5,10 @@ import (
 	"go.viam.com/rdk/utils"
 )
 
-// The model triplet for the rev-pi board.
+// Model is the model triplet for the rev-pi board.
 var Model = resource.NewModel("viam-labs", "kunbus", "revolutionpi")
 
-// The config for the rev-pi board.
+// Config is the config for the rev-pi board.
 type Config struct {
 	resource.TriviallyValidateConfig
 	Attributes utils.AttributeMap `json:"attributes,omitempty"`

--- a/revolution_pi/gpio_chip.go
+++ b/revolution_pi/gpio_chip.go
@@ -47,6 +47,7 @@ func (g *gpioChip) GetAnalogInput(pinName string) (*analogPin, error) {
 
 func (g *gpioChip) mapNameToAddress(pin *SPIVariable) error {
 	g.logger.Debugf("Looking for address of %#v", pin)
+	//nolint:gosec
 	err := g.ioCtl(uintptr(KB_FIND_VARIABLE), unsafe.Pointer(pin))
 	if err != 0 {
 		e := fmt.Errorf("failed to get pin address info %v failed: %w", g.dev, err)
@@ -59,6 +60,7 @@ func (g *gpioChip) mapNameToAddress(pin *SPIVariable) error {
 func (g *gpioChip) showDeviceList() error {
 	var deviceInfoList [255]SDeviceInfo
 	g.dioDevices = []SDeviceInfo{}
+	//nolint:gosec
 	cnt, _, err := g.ioCtlReturns(uintptr(KB_GET_DEVICE_INFO_LIST), unsafe.Pointer(&deviceInfoList))
 	if err != 0 {
 		e := fmt.Errorf("failed to retrieve device info list: %d", -int(cnt))
@@ -134,7 +136,6 @@ func (g *gpioChip) Close() error {
 }
 
 func (g *gpioChip) findDIODevice(gpioAddress uint16) (SDeviceInfo, error) {
-
 	for _, dev := range g.dioDevices {
 		// need to test devOffsetLower with multiple DIO devices
 		devOffsetLower := dev.i16uInputOffset

--- a/revolution_pi/gpio_chip.go
+++ b/revolution_pi/gpio_chip.go
@@ -101,7 +101,7 @@ func (g *gpioChip) ioCtlReturns(command uintptr, message unsafe.Pointer) (uintpt
 func (g *gpioChip) getBitValue(address int64, bitPosition uint8) (bool, error) {
 	b := make([]byte, 1)
 	n, err := g.fileHandle.ReadAt(b, address)
-	g.logger.Infof("Read %#v bytes", b)
+	g.logger.Debugf("Read %#v bytes", b)
 	if n != 1 {
 		return false, fmt.Errorf("expected 1 byte, got %#v", b)
 	}
@@ -139,7 +139,7 @@ func (g *gpioChip) findDIODevice(gpioAddress uint16) (SDeviceInfo, error) {
 		// need to test devOffsetLower with multiple DIO devices
 		devOffsetLower := dev.i16uInputOffset
 		devOffsetUpper := dev.i16uInputOffset + dev.i16uOutputLength + dev.i16uInputLength + dev.i16uConfigLength
-		if gpioAddress > devOffsetLower && gpioAddress < devOffsetUpper {
+		if gpioAddress >= devOffsetLower && gpioAddress < devOffsetUpper {
 			return dev, nil
 		}
 	}

--- a/revolution_pi/gpio_chip.go
+++ b/revolution_pi/gpio_chip.go
@@ -21,13 +21,13 @@ type gpioChip struct {
 }
 
 func (g *gpioChip) GetGPIOPin(pinName string) (*gpioPin, error) {
-	pin := SPIVariable{strVarName: Char32(pinName)}
+	pin := SPIVariable{strVarName: char32(pinName)}
 	err := g.mapNameToAddress(&pin)
 	if err != nil {
 		return nil, err
 	}
 	g.logger.Debugf("Found GPIO pin: %#v", pin)
-	gpioPin := gpioPin{Name: Str32(pin.strVarName), Address: pin.i16uAddress, BitPosition: pin.i8uBit, Length: pin.i16uLength, ControlChip: g}
+	gpioPin := gpioPin{Name: str32(pin.strVarName), Address: pin.i16uAddress, BitPosition: pin.i8uBit, Length: pin.i16uLength, ControlChip: g}
 	err = gpioPin.initialize()
 	if err != nil {
 		return nil, err
@@ -36,13 +36,13 @@ func (g *gpioChip) GetGPIOPin(pinName string) (*gpioPin, error) {
 }
 
 func (g *gpioChip) GetAnalogInput(pinName string) (*analogPin, error) {
-	pin := SPIVariable{strVarName: Char32(pinName)}
+	pin := SPIVariable{strVarName: char32(pinName)}
 	err := g.mapNameToAddress(&pin)
 	if err != nil {
 		return nil, err
 	}
 	g.logger.Debugf("Found Analog pin: %#v", pin)
-	return &analogPin{Name: Str32(pin.strVarName), Address: pin.i16uAddress, Length: pin.i16uLength, ControlChip: g}, nil
+	return &analogPin{Name: str32(pin.strVarName), Address: pin.i16uAddress, Length: pin.i16uLength, ControlChip: g}, nil
 }
 
 func (g *gpioChip) mapNameToAddress(pin *SPIVariable) error {
@@ -112,9 +112,8 @@ func (g *gpioChip) getBitValue(address int64, bitPosition uint8) (bool, error) {
 	}
 	if (b[0]>>bitPosition)&1 == 1 {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
 }
 
 func (g *gpioChip) writeValue(address int64, b []byte) error {

--- a/revolution_pi/gpio_chip.go
+++ b/revolution_pi/gpio_chip.go
@@ -110,9 +110,9 @@ func (g *gpioChip) getBitValue(address int64, bitPosition uint8) (bool, error) {
 }
 
 func (g *gpioChip) writeValue(address int64, b []byte) error {
-	g.logger.Debugf("Writing %#v to %v", b, address)
+	g.logger.Debugf("Writing %#d to %v", b, address)
 	n, err := g.fileHandle.WriteAt(b, address)
-	g.logger.Debugf("Wrote %#v byte(s), n: %v", b, n)
+	g.logger.Debugf("Wrote %#d byte(s), n: %d", b, n)
 	if err != nil {
 		return err
 	}

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -34,7 +34,7 @@ type gpioPin struct {
 func (pin *gpioPin) initialize() error {
 	dio, err := pin.ControlChip.findDIODevice(pin.Address)
 	if err != nil {
-		pin.ControlChip.logger.Debugf("pin is not from the DIO")
+		pin.ControlChip.logger.Debug("pin is not from the DIO")
 		return err
 	}
 
@@ -87,7 +87,6 @@ func (pin *gpioPin) getGpioAddress() uint16 {
 	default:
 		return pin.Address
 	}
-
 }
 
 // Set sets the state of the pin on or off.
@@ -122,6 +121,7 @@ func (pin *gpioPin) Set(ctx context.Context, high bool, extra map[string]interfa
 	// and writing back, we can leverage the ioctl command to modify 1 bit
 	command := SPIValue{i16uAddress: gpioAddress, i8uBit: gpioBit, i8uValue: val}
 	pin.ControlChip.logger.Debugf("Command: %#v", command)
+	//nolint:gosec
 	err := pin.ControlChip.ioCtl(uintptr(KB_SET_VALUE), unsafe.Pointer(&command))
 	if err != 0 {
 		return err
@@ -158,7 +158,6 @@ func (pin *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool
 
 // PWM gets the pin's given duty cycle.
 func (pin *gpioPin) PWM(ctx context.Context, extra map[string]interface{}) (float64, error) {
-
 	if !pin.initialized {
 		return 0, errors.New("pin not initialized")
 	}
@@ -268,7 +267,7 @@ func stepSizeToFreq(step []byte) uint {
 	return 0
 }
 
-// SetPWMFreq sets the given pin to the given PWM frequency. For the Rev-Pi this must be configured in PiCtory
+// SetPWMFreq sets the given pin to the given PWM frequency. For the Rev-Pi this must be configured in PiCtory.
 func (pin *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[string]interface{}) error {
 	if !pin.initialized {
 		return errors.New("pin not initialized")
@@ -277,22 +276,22 @@ func (pin *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[strin
 	return errors.New("PWM Frequency must be set in PiCtory")
 }
 
-// pins at 70 or 71 + inputOffset
+// pins at 70 or 71 + inputOffset.
 func (pin *gpioPin) isOutputWord() bool {
 	return pin.Address == pin.outputOffset || pin.Address == pin.outputOffset+1
 }
 
-// pins with an offset of 72 to 87 + inputOffset
+// pins with an offset of 72 to 87 + inputOffset.
 func (pin *gpioPin) isOutputPWM() bool {
 	return pin.Address > pin.outputOffset+outputWordToPWMOffset && pin.Address < pin.inputOffset+dioMemoryOffset
 }
 
-// pins at 0 or 1 + inputOffset
+// pins at 0 or 1 + inputOffset.
 func (pin *gpioPin) isInputWord() bool {
 	return pin.Address == pin.inputOffset || pin.Address == pin.inputOffset+1
 }
 
-// pins at 6 to 70 + inputOffset
+// pins at 6 to 70 + inputOffset.
 func (pin *gpioPin) isInputCounter() bool {
 	return pin.Address >= pin.inputOffset+inputWordToCounterOffset && pin.Address < pin.outputOffset
 }

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -264,6 +264,8 @@ func (pin *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (
 	return stepSizeToFreq(b), nil
 }
 
+// stepSizeToFreq returns the frequency based on the step size returned from the outputPWMFrequency address
+// see documentation for more information.
 func stepSizeToFreq(step []byte) uint {
 	// b only has one byte
 	switch step[0] {

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -56,7 +56,8 @@ func (pin *gpioPin) initialize() error {
 		// so we convert the pin address into the matching bits, where PWM_1 corresponds to bit 0.
 		// Output pins start at dio.i16uOutputOffset+2, so we can subtract pin address by that amount to get the correct bit
 		pwmActiveBitPosition := uint8(pin.Address - dio.i16uOutputOffset - outputWordToPWMOffset)
-		val, err = pin.ControlChip.getBitValue(int64(dio.i16uInputOffset+outputPWMActiveOffset+uint16(pwmActiveBitPosition/8)), pwmActiveBitPosition%8)
+		val, err = pin.ControlChip.getBitValue(int64(dio.i16uInputOffset+outputPWMActiveOffset+uint16(pwmActiveBitPosition/8)),
+			pwmActiveBitPosition%8)
 		if err != nil {
 			return err
 		}
@@ -284,11 +285,6 @@ func (pin *gpioPin) isOutputWord() bool {
 // pins with an offset of 72 to 87 + inputOffset.
 func (pin *gpioPin) isOutputPWM() bool {
 	return pin.Address > pin.outputOffset+outputWordToPWMOffset && pin.Address < pin.inputOffset+dioMemoryOffset
-}
-
-// pins at 0 or 1 + inputOffset.
-func (pin *gpioPin) isInputWord() bool {
-	return pin.Address == pin.inputOffset || pin.Address == pin.inputOffset+1
 }
 
 // pins at 6 to 70 + inputOffset.

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -104,10 +104,13 @@ func (pin *gpioPin) Set(ctx context.Context, high bool, extra map[string]interfa
 
 // Get gets the high/low state of the pin.
 func (pin *gpioPin) Get(ctx context.Context, extra map[string]interface{}) (bool, error) {
-	pin.ControlChip.logger.Debugf("Reading from %v", pin.getGpioAddress())
+	pin.ControlChip.logger.Infof("Reading from %v", pin.getGpioAddress())
 
 	if !pin.initialized {
 		return false, errors.New("pin not initialized")
+	}
+	if pin.pwmMode {
+		return false, fmt.Errorf("cannot get pin state, Pin %s is configured as PWM", pin.Name)
 	}
 	return pin.ControlChip.getBitValue(int64(pin.getGpioAddress()), pin.BitPosition)
 }

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -134,9 +134,9 @@ func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[
 		}
 	}
 
-	pwmAddress := pin.getPwmAddress()
-	pin.ControlChip.logger.Infof("initial Address to %v", pin.Address)
-	pin.ControlChip.logger.Infof("Writing to %v", pwmAddress)
+	// pwmAddress := pin.getPwmAddress()
+	// pin.ControlChip.logger.Infof("initial Address to %v", pin.Address)
+	// pin.ControlChip.logger.Infof("Writing to %v", pwmAddress)
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, uint16(dutyCyclePct))
 	b = b[:1]
@@ -193,6 +193,9 @@ func (pin *gpioPin) enablePwm() error {
 	// Much like in Set, we can't modify a single bit using the regular read/write in file stream
 	// so we have to use the ioctl command to modify just a single bit
 	command := SPIValue{i16uAddress: 110 + (pin.Address - 70), i8uBit: pin.BitPosition, i8uValue: 1}
+	pin.ControlChip.logger.Info("address: ", command.i16uAddress)
+	pin.ControlChip.logger.Info("position: ", command.i8uBit)
+	pin.ControlChip.logger.Info("value: ", command.i8uValue)
 	syscallErr := pin.ControlChip.ioCtl(uintptr(KB_SET_VALUE), unsafe.Pointer(&command))
 	if syscallErr != 0 {
 		return fmt.Errorf("error turning on pwm for output: %w", syscallErr)

--- a/revolution_pi/gpio_pin.go
+++ b/revolution_pi/gpio_pin.go
@@ -11,6 +11,11 @@ import (
 	"unsafe"
 )
 
+const (
+	outputPWMActiveOffset    = 110 // offset for reading a PWM frequency from a DIO
+	outputPWMFrequencyOffset = 112
+)
+
 type gpioPin struct {
 	Name        string // Variable name
 	Address     uint16 // Address of the byte in the process image
@@ -22,10 +27,32 @@ type gpioPin struct {
 }
 
 func (pin *gpioPin) initialize() error {
-	val, err := pin.ControlChip.getBitValue(int64(110+(pin.Address-70)), pin.BitPosition)
+	dio, err := pin.ControlChip.findDIODevice(pin.Address)
 	if err != nil {
+		pin.ControlChip.logger.Debugf("pin is not from the DIO")
 		return err
 	}
+	var val bool
+	// if the requested pin is checking the Output WORD
+	if pin.Address == dio.i16uOutputOffset {
+		val, err = pin.ControlChip.getBitValue(int64(dio.i16uInputOffset+outputPWMActiveOffset), pin.BitPosition)
+		if err != nil {
+			return err
+		}
+	} else {
+		// we want to read a bit from OutputPWMActive WORD to see if pwm is enabled,
+		// so we convert the pin address into the matching bits, where PWM_1 corresponds to bit 0.
+		// Output pins start at dio.i16uOutputOffset+2, so we can subtract pin address by that amount to get the correct bit
+		pwmActiveBitPosition := uint8(pin.Address - dio.i16uOutputOffset - 2)
+		val, err = pin.ControlChip.getBitValue(int64(dio.i16uInputOffset+outputPWMActiveOffset), pwmActiveBitPosition)
+		if err != nil {
+			return err
+		}
+	}
+
+	pin.ControlChip.logger.Infof("address: %d", pin.Address)
+	pin.ControlChip.logger.Infof("i16uAddress: %d", dio.i16uInputOffset+outputPWMActiveOffset)
+	pin.ControlChip.logger.Infof("position: %d", pin.BitPosition)
 	pin.pwmMode = val
 	pin.initialized = true
 	pin.ControlChip.logger.Infof("Pin initialized: %#v", pin)
@@ -57,10 +84,11 @@ func (pin *gpioPin) Set(ctx context.Context, high bool, extra map[string]interfa
 
 	// disable pwm if enabled
 	if pin.pwmMode {
-		err := pin.disablePwm()
-		if err != nil {
-			return err
-		}
+		// err := pin.disablePwm()
+		// if err != nil {
+		// 	return err
+		// }
+		return fmt.Errorf("cannot set pin state, Pin %s is configured as PWM", pin.Name)
 	}
 
 	// Because there could be a race in reading the byte with pin states, mutating,
@@ -128,10 +156,11 @@ func (pin *gpioPin) SetPWM(ctx context.Context, dutyCyclePct float64, extra map[
 
 	// if the pin isn't in PWM mode, we have to turn PWM on
 	if !pin.pwmMode {
-		err := pin.enablePwm()
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("pin %s is not configured for PWM", pin.Name)
+		// err := pin.enablePwm()
+		// if err != nil {
+		// 	return err
+		// }
 	}
 
 	// pwmAddress := pin.getPwmAddress()
@@ -150,17 +179,39 @@ func (pin *gpioPin) PWMFreq(ctx context.Context, extra map[string]interface{}) (
 		return 0, errors.New("pin not initialized")
 	}
 
+	dio, err := pin.ControlChip.findDIODevice(pin.Address)
+	if err != nil {
+		return 0, err
+	}
+
 	b := make([]byte, 1)
-	n, err := pin.ControlChip.fileHandle.ReadAt(b, 112)
+	n, err := pin.ControlChip.fileHandle.ReadAt(b, int64(dio.i16uInputOffset+outputPWMFrequencyOffset))
 	if err != nil {
 		return 0, err
 	}
 	if n != 1 {
 		return 0, errors.New("unable to read PWM Frequency")
 	}
-	pin.ControlChip.logger.Infof("Current frequency: %#v", b)
+	pin.ControlChip.logger.Debugf("Current frequency: %#d", b)
 
-	return 0, nil
+	return stepSizeToFreq(b), nil
+}
+
+func stepSizeToFreq(step []byte) uint {
+	// b only has one byte
+	switch step[0] {
+	case 1:
+		return 40
+	case 2:
+		return 80
+	case 4:
+		return 160
+	case 5:
+		return 200
+	case 10:
+		return 400
+	}
+	return 0
 }
 
 // SetPWMFreq sets the given pin to the given PWM frequency. For Raspberry Pis,
@@ -170,7 +221,7 @@ func (pin *gpioPin) SetPWMFreq(ctx context.Context, freqHz uint, extra map[strin
 		return errors.New("pin not initialized")
 	}
 
-	return errors.New("not supported")
+	return errors.New("PWM Frequency must be set in PiCtory")
 }
 
 // disablePwm sets the bit to turn off PWM for the pin in the controller.
@@ -192,8 +243,15 @@ func (pin *gpioPin) enablePwm() error {
 	// We actually need to enable PWM for the pin, we can't just set the PWM value
 	// Much like in Set, we can't modify a single bit using the regular read/write in file stream
 	// so we have to use the ioctl command to modify just a single bit
-	command := SPIValue{i16uAddress: 110 + (pin.Address - 70), i8uBit: pin.BitPosition, i8uValue: 1}
-	pin.ControlChip.logger.Info("address: ", command.i16uAddress)
+
+	// find DIO device
+	dio, err := pin.ControlChip.findDIODevice(pin.Address)
+	if err != nil {
+		return err
+	}
+	command := SPIValue{i16uAddress: dio.i16uInputOffset + 112, i8uBit: pin.BitPosition, i8uValue: 1}
+	pin.ControlChip.logger.Info("address: ", pin.Address)
+	pin.ControlChip.logger.Info("i16uAddress: ", command.i16uAddress)
 	pin.ControlChip.logger.Info("position: ", command.i8uBit)
 	pin.ControlChip.logger.Info("value: ", command.i8uValue)
 	syscallErr := pin.ControlChip.ioCtl(uintptr(KB_SET_VALUE), unsafe.Pointer(&command))

--- a/revolution_pi/io_util.go
+++ b/revolution_pi/io_util.go
@@ -75,13 +75,12 @@ type SDeviceInfo struct {
 	i8uReserve       [30]uint8 // space for future extensions without changing the size of the struct
 }
 
+// isDIO checks whether the module is a DIO, DO, or DI module, which can be used with our GPIO related apis
 func (dev *SDeviceInfo) isDIO() bool {
-	if dev.i16uModuleType == 96 || dev.i16uModuleType == 97 || dev.i16uModuleType == 98 {
-		return true
-	}
-	return false
+	return dev.i16uModuleType == 96 || dev.i16uModuleType == 97 || dev.i16uModuleType == 98
 }
 
+// getModuleName gets the module name based on the module type
 func getModuleName(moduleType uint16) string {
 	switch {
 	case moduleType == 95:

--- a/revolution_pi/io_util.go
+++ b/revolution_pi/io_util.go
@@ -1,36 +1,36 @@
 package revolution_pi
 
-func ioctl_address(v int) int {
-	kb_ioc_magic := int('K')
-	magic := (((0) << (((0 + 8) + 8) + 14)) | ((kb_ioc_magic) << (0 + 8)) | ((v) << 0) | ((0) << ((0 + 8) + 8)))
+func ioctlAddress(v int) int {
+	kbIocMagic := int('K')
+	magic := (((0) << (((0 + 8) + 8) + 14)) | ((kbIocMagic) << (0 + 8)) | ((v) << 0) | ((0) << ((0 + 8) + 8)))
 	return magic
 }
 
 const PICONTROL_NOT_CONNECTED = 0x8000
 
 var (
-	KB_CMD1                   = ioctl_address(10) // for test only
-	KB_CMD2                   = ioctl_address(11) // for test only
-	KB_RESET                  = ioctl_address(12) // reset the piControl driver including the config file
-	KB_GET_DEVICE_INFO_LIST   = ioctl_address(13) // get the device info of all detected devices
-	KB_GET_DEVICE_INFO        = ioctl_address(14) // get the device info of one device
-	KB_GET_VALUE              = ioctl_address(15) // get the value of one bit in the process image
-	KB_SET_VALUE              = ioctl_address(16) // set the value of one bit in the process image
-	KB_FIND_VARIABLE          = ioctl_address(17) // find a variable defined in piCtory
-	KB_SET_EXPORTED_OUTPUTS   = ioctl_address(18) // copy the exported outputs from a application process image to the real process image
-	KB_UPDATE_DEVICE_FIRMWARE = ioctl_address(19) // try to update the firmware of connected devices
-	KB_DIO_RESET_COUNTER      = ioctl_address(20) // set a counter or encoder to 0
-	KB_GET_LAST_MESSAGE       = ioctl_address(21) // copy the last error message
-	KB_STOP_IO                = ioctl_address(22) // stop/start IO communication, can be used for I/O simulation
-	KB_CONFIG_STOP            = ioctl_address(23) // for download of configuration to Master Gateway: stop IO communication completely
-	KB_CONFIG_SEND            = ioctl_address(24) // for download of configuration to Master Gateway: download config data
-	KB_CONFIG_START           = ioctl_address(25) // for download of configuration to Master Gateway: restart IO communication
-	KB_SET_OUTPUT_WATCHDOG    = ioctl_address(26) // activate a watchdog for this handle. If write is not called for a given period all outputs are set to 0
-	KB_SET_POS                = ioctl_address(27) // set the f_pos, the unsigned int * is used to interpret the pos value
-	KB_AIO_CALIBRATE          = ioctl_address(28)
+	KB_CMD1                   = ioctlAddress(10) // for test only
+	KB_CMD2                   = ioctlAddress(11) // for test only
+	KB_RESET                  = ioctlAddress(12) // reset the piControl driver including the config file
+	KB_GET_DEVICE_INFO_LIST   = ioctlAddress(13) // get the device info of all detected devices
+	KB_GET_DEVICE_INFO        = ioctlAddress(14) // get the device info of one device
+	KB_GET_VALUE              = ioctlAddress(15) // get the value of one bit in the process image
+	KB_SET_VALUE              = ioctlAddress(16) // set the value of one bit in the process image
+	KB_FIND_VARIABLE          = ioctlAddress(17) // find a variable defined in piCtory
+	KB_SET_EXPORTED_OUTPUTS   = ioctlAddress(18) // copy the exported outputs from a application process image to the real process image
+	KB_UPDATE_DEVICE_FIRMWARE = ioctlAddress(19) // try to update the firmware of connected devices
+	KB_DIO_RESET_COUNTER      = ioctlAddress(20) // set a counter or encoder to 0
+	KB_GET_LAST_MESSAGE       = ioctlAddress(21) // copy the last error message
+	KB_STOP_IO                = ioctlAddress(22) // stop/start IO communication, can be used for I/O simulation
+	KB_CONFIG_STOP            = ioctlAddress(23) // for download of configuration to Master Gateway: stop IO communication completely
+	KB_CONFIG_SEND            = ioctlAddress(24) // for download of configuration to Master Gateway: download config data
+	KB_CONFIG_START           = ioctlAddress(25) // for download of configuration to Master Gateway: restart IO communication
+	KB_SET_OUTPUT_WATCHDOG    = ioctlAddress(26) // activate a watchdog for this handle. If write is not called for a given period all outputs are set to 0
+	KB_SET_POS                = ioctlAddress(27) // set the f_pos, the unsigned int * is used to interpret the pos value
+	KB_AIO_CALIBRATE          = ioctlAddress(28)
 )
 
-var KB_WAIT_FOR_EVENT = ioctl_address(50) // wait for an event. This call is normally blocking
+var KB_WAIT_FOR_EVENT = ioctlAddress(50) // wait for an event. This call is normally blocking
 
 type SPIVariable struct {
 	strVarName  [32]byte // Variable name
@@ -45,20 +45,22 @@ type SPIValue struct {
 	i8uValue    uint8  // Value: 0/1 for bit access, whole byte otherwise
 }
 
+//nolint:unused
 type PwmStateRequest struct {
 	i16uAddress uint16 // Address of the byte in the process image
 	i8uBit      uint8  // 0-7 bit position, >= 8 whole byte
 	i8uValue    uint16 // Value: 0/1 for bit access, whole byte otherwise
 }
 
+//nolint:unused
 type SDeviceInfo struct {
 	i8uAddress       uint8     // Address of module in current configuration
 	i32uSerialnumber uint32    // serial number of module
 	i16uModuleType   uint16    // Type identifier of module
-	i16uHW_Revision  uint16    // hardware revision
-	i16uSW_Major     uint16    // major software version
-	i16uSW_Minor     uint16    // minor software version
-	i32uSVN_Revision uint32    // svn revision of software
+	i16uHWRevision   uint16    // hardware revision
+	i16uSWMajor      uint16    // major software version
+	i16uSWMinor      uint16    // minor software version
+	i32uSVNRevision  uint32    // svn revision of software
 	i16uInputLength  uint16    // length in bytes of all input values together
 	i16uOutputLength uint16    // length in bytes of all output values together
 	i16uConfigLength uint16    // length in bytes of all config values together

--- a/revolution_pi/io_util.go
+++ b/revolution_pi/io_util.go
@@ -73,6 +73,13 @@ type SDeviceInfo struct {
 	i8uReserve       [30]uint8 // space for future extensions without changing the size of the struct
 }
 
+func (dev *SDeviceInfo) isDIO() bool {
+	if dev.i16uModuleType == 96 || dev.i16uModuleType == 97 || dev.i16uModuleType == 98 {
+		return true
+	}
+	return false
+}
+
 func getModuleName(moduleType uint16) string {
 	switch {
 	case moduleType == 95:

--- a/revolution_pi/revolution_pi.go
+++ b/revolution_pi/revolution_pi.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-// Package revolution_pi implements the Revolution Pi board GPIO pins.
+// Package revolution-pi implements the Revolution Pi board GPIO pins.
 package revolution_pi
 
 import (
@@ -20,7 +20,7 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-type revolutionPiBoard struct {
+type revolution_piBoard struct {
 	resource.Named
 	resource.TriviallyReconfigurable
 
@@ -48,8 +48,9 @@ func newBoard(
 	conf resource.Config,
 	logger logging.Logger,
 ) (board.Board, error) {
-	logger.Info("Starting RevolutionPi Driver v0.0.5")
+	logger.Info("Starting revolution_pi Driver v0.0.5")
 	devPath := filepath.Join("/dev", "piControl0")
+	//nolint:gosec
 	fd, err := os.OpenFile(devPath, os.O_RDWR, fs.FileMode(os.O_RDWR))
 	if err != nil {
 		err = fmt.Errorf("open chip %v failed: %w", devPath, err)
@@ -57,7 +58,7 @@ func newBoard(
 	}
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	gpioChip := gpioChip{dev: devPath, logger: logger, fileHandle: fd}
-	b := revolutionPiBoard{
+	b := revolution_piBoard{
 		Named:         conf.ResourceName().AsNamed(),
 		logger:        logger,
 		cancelCtx:     cancelCtx,
@@ -76,7 +77,7 @@ func newBoard(
 	return &b, nil
 }
 
-func (b *revolutionPiBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) {
+func (b *revolution_piBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	reader, err := b.controlChip.GetAnalogInput(name)
 	if err != nil {
 		b.logger.Error(err)
@@ -86,39 +87,39 @@ func (b *revolutionPiBoard) AnalogReaderByName(name string) (board.AnalogReader,
 	return reader, true
 }
 
-func (b *revolutionPiBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
+func (b *revolution_piBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
 	return nil, false // Digital interrupts aren't supported.
 }
 
-func (b *revolutionPiBoard) AnalogReaderNames() []string {
+func (b *revolution_piBoard) AnalogReaderNames() []string {
 	return nil
 }
 
-func (b *revolutionPiBoard) DigitalInterruptNames() []string {
+func (b *revolution_piBoard) DigitalInterruptNames() []string {
 	return nil
 }
 
-func (b *revolutionPiBoard) GPIOPinNames() []string {
+func (b *revolution_piBoard) GPIOPinNames() []string {
 	return nil
 }
 
-func (b *revolutionPiBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
+func (b *revolution_piBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	return b.controlChip.GetGPIOPin(pinName)
 }
 
-func (b *revolutionPiBoard) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (b *revolution_piBoard) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
 	return &commonpb.BoardStatus{}, nil
 }
 
-func (b *revolutionPiBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
+func (b *revolution_piBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	return grpc.UnimplementedError
 }
 
-func (b *revolutionPiBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *revolution_piBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
 	return nil
 }
 
-func (b *revolutionPiBoard) Close(ctx context.Context) error {
+func (b *revolution_piBoard) Close(ctx context.Context) error {
 	b.mu.Lock()
 	b.logger.Info("Closing RevPi board.")
 	defer b.mu.Unlock()
@@ -132,7 +133,7 @@ func (b *revolutionPiBoard) Close(ctx context.Context) error {
 	return nil
 }
 
-func (b *revolutionPiBoard) DoCommand(ctx context.Context,
+func (b *revolution_piBoard) DoCommand(ctx context.Context,
 	req map[string]interface{},
 ) (map[string]interface{}, error) {
 	resp := make(map[string]interface{})

--- a/revolution_pi/revolution_pi.go
+++ b/revolution_pi/revolution_pi.go
@@ -20,7 +20,7 @@ import (
 	"go.viam.com/rdk/resource"
 )
 
-type revolution_piBoard struct {
+type revolutionPiBoard struct {
 	resource.Named
 	resource.TriviallyReconfigurable
 
@@ -48,7 +48,7 @@ func newBoard(
 	conf resource.Config,
 	logger logging.Logger,
 ) (board.Board, error) {
-	logger.Info("Starting revolution_pi Driver v0.0.5")
+	logger.Info("Starting RevolutionPi Driver v0.0.5")
 	devPath := filepath.Join("/dev", "piControl0")
 	//nolint:gosec
 	fd, err := os.OpenFile(devPath, os.O_RDWR, fs.FileMode(os.O_RDWR))
@@ -58,7 +58,7 @@ func newBoard(
 	}
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 	gpioChip := gpioChip{dev: devPath, logger: logger, fileHandle: fd}
-	b := revolution_piBoard{
+	b := revolutionPiBoard{
 		Named:         conf.ResourceName().AsNamed(),
 		logger:        logger,
 		cancelCtx:     cancelCtx,
@@ -77,7 +77,7 @@ func newBoard(
 	return &b, nil
 }
 
-func (b *revolution_piBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) {
+func (b *revolutionPiBoard) AnalogReaderByName(name string) (board.AnalogReader, bool) {
 	reader, err := b.controlChip.GetAnalogInput(name)
 	if err != nil {
 		b.logger.Error(err)
@@ -87,39 +87,39 @@ func (b *revolution_piBoard) AnalogReaderByName(name string) (board.AnalogReader
 	return reader, true
 }
 
-func (b *revolution_piBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
+func (b *revolutionPiBoard) DigitalInterruptByName(name string) (board.DigitalInterrupt, bool) {
 	return nil, false // Digital interrupts aren't supported.
 }
 
-func (b *revolution_piBoard) AnalogReaderNames() []string {
+func (b *revolutionPiBoard) AnalogReaderNames() []string {
 	return nil
 }
 
-func (b *revolution_piBoard) DigitalInterruptNames() []string {
+func (b *revolutionPiBoard) DigitalInterruptNames() []string {
 	return nil
 }
 
-func (b *revolution_piBoard) GPIOPinNames() []string {
+func (b *revolutionPiBoard) GPIOPinNames() []string {
 	return nil
 }
 
-func (b *revolution_piBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
+func (b *revolutionPiBoard) GPIOPinByName(pinName string) (board.GPIOPin, error) {
 	return b.controlChip.GetGPIOPin(pinName)
 }
 
-func (b *revolution_piBoard) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
+func (b *revolutionPiBoard) Status(ctx context.Context, extra map[string]interface{}) (*commonpb.BoardStatus, error) {
 	return &commonpb.BoardStatus{}, nil
 }
 
-func (b *revolution_piBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
+func (b *revolutionPiBoard) SetPowerMode(ctx context.Context, mode pb.PowerMode, duration *time.Duration) error {
 	return grpc.UnimplementedError
 }
 
-func (b *revolution_piBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
+func (b *revolutionPiBoard) WriteAnalog(ctx context.Context, pin string, value int32, extra map[string]interface{}) error {
 	return nil
 }
 
-func (b *revolution_piBoard) Close(ctx context.Context) error {
+func (b *revolutionPiBoard) Close(ctx context.Context) error {
 	b.mu.Lock()
 	b.logger.Info("Closing RevPi board.")
 	defer b.mu.Unlock()
@@ -133,7 +133,7 @@ func (b *revolution_piBoard) Close(ctx context.Context) error {
 	return nil
 }
 
-func (b *revolution_piBoard) DoCommand(ctx context.Context,
+func (b *revolutionPiBoard) DoCommand(ctx context.Context,
 	req map[string]interface{},
 ) (map[string]interface{}, error) {
 	resp := make(map[string]interface{})

--- a/revolution_pi/revolution_pi.go
+++ b/revolution_pi/revolution_pi.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-// Package revolution-pi implements the Revolution Pi board GPIO pins.
+// Package revolution_pi implements the Revolution Pi board GPIO pins.
 package revolution_pi
 
 import (

--- a/revolution_pi/revolution_pi_nonlinux.go
+++ b/revolution_pi/revolution_pi_nonlinux.go
@@ -1,2 +1,3 @@
+// Package revolution_pi implements the Revolution Pi board GPIO pins.
 // This is a non-linux package implementation for the revolution pi.
 package revolution_pi

--- a/revolution_pi/util.go
+++ b/revolution_pi/util.go
@@ -1,7 +1,7 @@
-// Package revolution-pi implements the Revolution Pi board GPIO pins.
+// Package revolution_pi implements the Revolution Pi board GPIO pins.
 package revolution_pi
 
-func Str32(chars [32]byte) string {
+func str32(chars [32]byte) string {
 	i := 0
 	var c byte
 	for i, c = range chars {
@@ -12,7 +12,7 @@ func Str32(chars [32]byte) string {
 	return string(chars[:i])
 }
 
-func Char32(str string) (chars [32]byte) {
+func char32(str string) (chars [32]byte) {
 	copy(chars[:31], str)
 	return
 }

--- a/revolution_pi/util.go
+++ b/revolution_pi/util.go
@@ -1,3 +1,4 @@
+// Package revolution-pi implements the Revolution Pi board GPIO pins.
 package revolution_pi
 
 func Str32(chars [32]byte) string {


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7236

sets up the GPIO and PWM pins when using a DIO board for a rev pi. Had to change some logic in order to handle multiple DIO devices. 

Additionally I went alittle overkill and setup pins to map to their physical counterparts. Basically this means if output pin O1 is configured to be a pwm, you can use O_1 or PWM_1 to control that pwm. Same is true for getting & setting GPIO states. 

If you want to test this, the robot can be found [here](https://app.viam.com/robot?id=f76265a9-f8b7-4fe6-9499-53075da5f71b&tab=control) and the rev-pi software can be found [here](https://revpi109467.local:41443/pictory/index.html?hn=6b2936aff7c8398975df8dc76848d709). Currently only output pins 1, 2, 3, and 9 are configured for PWM