### PR TITLE
[RSDK-7596] setup encoder model

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -7,6 +7,10 @@
     {
       "api": "rdk:component:board",
       "model": "viam-labs:kunbus:revolutionpi"
+    },
+    {
+      "api": "rdk:component:encoder",
+      "model": "viam-labs:kunbus:revolutionpi-encoder"
     }
   ],
   "entrypoint": "viam-revolution-pi"

--- a/module.go
+++ b/module.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.viam.com/rdk/components/board"
+	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
 	"go.viam.com/utils"
@@ -25,6 +26,10 @@ func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (er
 	}
 
 	err = customModule.AddModelFromRegistry(ctx, board.API, revolutionpi.Model)
+	if err != nil {
+		return err
+	}
+	err = customModule.AddModelFromRegistry(ctx, encoder.API, revolutionpi.EncoderModel)
 	if err != nil {
 		return err
 	}

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -16,6 +16,8 @@ const (
 	inputModeOffset = 88
 )
 
+// digitalInterrupt is the struct used for configuring an interrupt or encoder.
+// encoders and digital interrupts are configured the same way in the revolution pi.
 type digitalInterrupt struct {
 	pinName          string // Variable name
 	address          uint16 // address of the byte in the process image
@@ -29,6 +31,7 @@ type digitalInterrupt struct {
 	interruptAddress uint16
 }
 
+// diWrapper wraps a digital interrupt pin with the DigitalInterrupt interface
 type diWrapper struct {
 	pin *digitalInterrupt
 }

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -31,7 +31,7 @@ type digitalInterrupt struct {
 	interruptAddress uint16
 }
 
-// diWrapper wraps a digital interrupt pin with the DigitalInterrupt interface
+// diWrapper wraps a digital interrupt pin with the DigitalInterrupt interface.
 type diWrapper struct {
 	pin *digitalInterrupt
 }

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -18,6 +18,10 @@ const (
 
 // digitalInterrupt is the struct used for configuring an interrupt or encoder.
 // encoders and digital interrupts are configured the same way in the revolution pi.
+// the encoder & digital interrupt interface cannot be satisfied by the same struct due
+// to both interfaces requiring different Name() methods.
+// Go does not allow for overloads, so instead the revolutionPiEncoder and diWrapper structs
+// are used to implement their respective interfaces.
 type digitalInterrupt struct {
 	pinName          string // Variable name
 	address          uint16 // address of the byte in the process image

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -30,7 +30,7 @@ type digitalInterrupt struct {
 }
 
 type diWrapper struct {
-	pin digitalInterrupt
+	pin *digitalInterrupt
 }
 
 func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip, isEncoder bool) (*digitalInterrupt, error) {

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -31,7 +31,6 @@ type digitalInterrupt struct {
 	outputOffset     uint16
 	inputOffset      uint16
 	enabled          bool
-	isEncoder        bool
 	interruptAddress uint16
 }
 
@@ -89,10 +88,11 @@ func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip, isEncoder bool) (*
 	// b[0] == 0 means the interrupt is disabled, b[0] == 3 means the pin is configured for encoder mode
 	if b[0] == 0 || (b[0] == 3 && !isEncoder) {
 		return &digitalInterrupt{}, fmt.Errorf("pin %s is not configured as a counter", di.pinName)
+	} else if b[0] != 3 && isEncoder {
+		return &digitalInterrupt{}, fmt.Errorf("pin %s is not configured as an encoder", di.pinName)
 	}
 
 	di.enabled = true
-	di.isEncoder = b[0] == 3
 
 	return &di, nil
 }

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -81,7 +81,7 @@ func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip, isEncoder bool) (*
 	// check if the pin is configured as a counter
 	// b[0] == 0 means the interrupt is disabled, b[0] == 3 means the pin is configured for encoder mode
 	if b[0] == 0 || (b[0] == 3 && !isEncoder) {
-		return &digitalInterrupt{}, errors.New("pin is not configured as a counter")
+		return &digitalInterrupt{}, fmt.Errorf("pin %s is not configured as a counter", di.pinName)
 	}
 
 	di.enabled = true

--- a/revolutionpi/digital_interrupts.go
+++ b/revolutionpi/digital_interrupts.go
@@ -25,10 +25,15 @@ type digitalInterrupt struct {
 	outputOffset     uint16
 	inputOffset      uint16
 	enabled          bool
+	isEncoder        bool
 	interruptAddress uint16
 }
 
-func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip) (*digitalInterrupt, error) {
+type diWrapper struct {
+	pin digitalInterrupt
+}
+
+func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip, isEncoder bool) (*digitalInterrupt, error) {
 	di := digitalInterrupt{
 		pinName: str32(pin.strVarName), address: pin.i16uAddress,
 		length: pin.i16uLength, bitPosition: pin.i8uBit, controlChip: g,
@@ -75,16 +80,22 @@ func initializeDigitalInterrupt(pin SPIVariable, g *gpioChip) (*digitalInterrupt
 
 	// check if the pin is configured as a counter
 	// b[0] == 0 means the interrupt is disabled, b[0] == 3 means the pin is configured for encoder mode
-	if b[0] == 0 || b[0] == 3 {
+	if b[0] == 0 || (b[0] == 3 && !isEncoder) {
 		return &digitalInterrupt{}, errors.New("pin is not configured as a counter")
 	}
+
 	di.enabled = true
+	di.isEncoder = b[0] == 3
 
 	return &di, nil
 }
 
+func (di *diWrapper) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+	return di.pin.Value()
+}
+
 // Note: The revolution pi only supports uint32 counters, while the Value API expects int64.
-func (di *digitalInterrupt) Value(ctx context.Context, extra map[string]interface{}) (int64, error) {
+func (di *digitalInterrupt) Value() (int64, error) {
 	if !di.enabled {
 		return 0, fmt.Errorf("cannot get digital interrupt value, pin %s is not configured as an interrupt", di.pinName)
 	}
@@ -102,13 +113,13 @@ func (di *digitalInterrupt) Value(ctx context.Context, extra map[string]interfac
 	return int64(val), nil
 }
 
-func (di *digitalInterrupt) Name() string {
-	return di.pinName
+func (di *diWrapper) Name() string {
+	return di.pin.pinName
 }
 
-func (di *digitalInterrupt) RemoveCallback(c chan board.Tick) {}
+func (di *diWrapper) RemoveCallback(c chan board.Tick) {}
 
-func (di *digitalInterrupt) Close(ctx context.Context) error {
+func (di *diWrapper) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -13,11 +13,12 @@ import (
 	"go.viam.com/rdk/components/encoder"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/utils"
 )
 
 type revolutionPiEncoder struct {
 	resource.Named
-	resource.TriviallyReconfigurable
+	resource.AlwaysRebuild
 	pin *digitalInterrupt
 }
 
@@ -26,8 +27,7 @@ var EncoderModel = resource.NewModel("viam-labs", "kunbus", "revolutionpi-encode
 
 // EncoderConfig is the config for the rev-pi board encoder.
 type EncoderConfig struct {
-	resource.TriviallyValidateConfig
-	Name string `json:"address_name,omitempty"`
+	Name string `json:"pin_name"`
 }
 
 func init() {
@@ -35,6 +35,13 @@ func init() {
 		encoder.API,
 		EncoderModel,
 		resource.Registration[encoder.Encoder, *EncoderConfig]{Constructor: newEncoder})
+}
+
+func (cfg *EncoderConfig) Validate(path string) ([]string, error) {
+	if cfg.Name == "" {
+		return nil, utils.NewConfigValidationFieldRequiredError(path, "pin_name")
+	}
+	return []string{}, nil
 }
 
 func newEncoder(

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -27,7 +27,7 @@ var EncoderModel = resource.NewModel("viam-labs", "kunbus", "revolutionpi-encode
 // EncoderConfig is the config for the rev-pi board encoder.
 type EncoderConfig struct {
 	resource.TriviallyValidateConfig
-	Name string `json:"name,omitempty"`
+	Name string `json:"address_name,omitempty"`
 }
 
 func init() {

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -74,7 +74,7 @@ func newEncoder(
 	if !enc.isEncoder {
 		return nil, fmt.Errorf("pin %s is not configured as an encoder", name)
 	}
-	return &revolutionPiEncoder{pin: enc}, nil
+	return &revolutionPiEncoder{Named: conf.ResourceName().AsNamed(), pin: enc}, nil
 }
 
 func (enc *revolutionPiEncoder) Position(ctx context.Context, positionType encoder.PositionType,

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -97,5 +97,5 @@ func (enc *revolutionPiEncoder) DoCommand(ctx context.Context, req map[string]in
 }
 
 func (enc *revolutionPiEncoder) Close(ctx context.Context) error {
-	return nil
+	return enc.pin.controlChip.Close()
 }

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -16,7 +16,7 @@ import (
 	"go.viam.com/utils"
 )
 
-// revolutionPiEncoder wraps a digital interrupt pin with the Encoder interface
+// revolutionPiEncoder wraps a digital interrupt pin with the Encoder interface.
 type revolutionPiEncoder struct {
 	resource.Named
 	resource.AlwaysRebuild
@@ -38,6 +38,7 @@ func init() {
 		resource.Registration[encoder.Encoder, *EncoderConfig]{Constructor: newEncoder})
 }
 
+// Validate validates the EncoderConfig.
 func (cfg *EncoderConfig) Validate(path string) ([]string, error) {
 	if cfg.Name == "" {
 		return nil, utils.NewConfigValidationFieldRequiredError(path, "pin_name")
@@ -61,20 +62,20 @@ func newEncoder(
 		err = fmt.Errorf("open chip %v failed: %w", devPath, err)
 		return nil, err
 	}
-	gpioChip := gpioChip{dev: devPath, logger: logger, fileHandle: fd}
+	chip := gpioChip{dev: devPath, logger: logger, fileHandle: fd}
 
-	err = gpioChip.showDeviceList()
+	err = chip.showDeviceList()
 	if err != nil {
 		return nil, err
 	}
 	name := svcConfig.Name
 	pin := SPIVariable{strVarName: char32(name)}
-	err = gpioChip.mapNameToAddress(&pin)
+	err = chip.mapNameToAddress(&pin)
 	if err != nil {
 		return nil, err
 	}
 
-	enc, err := initializeDigitalInterrupt(pin, &gpioChip, true)
+	enc, err := initializeDigitalInterrupt(pin, &chip, true)
 	if err != nil {
 		return nil, err
 	}

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -79,9 +79,7 @@ func newEncoder(
 	if err != nil {
 		return nil, err
 	}
-	if !enc.isEncoder {
-		return nil, fmt.Errorf("pin %s is not configured as an encoder", name)
-	}
+
 	return &revolutionPiEncoder{Named: conf.ResourceName().AsNamed(), pin: enc}, nil
 }
 

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -16,6 +16,7 @@ import (
 	"go.viam.com/utils"
 )
 
+// revolutionPiEncoder wraps a digital interrupt pin with the Encoder interface
 type revolutionPiEncoder struct {
 	resource.Named
 	resource.AlwaysRebuild
@@ -54,8 +55,7 @@ func newEncoder(
 	if err != nil {
 		return nil, err
 	}
-	devPath := filepath.Join("/dev", "piControl0")
-	devPath = filepath.Clean(devPath)
+	devPath := filepath.Clean(filepath.Join("/dev", "piControl0"))
 	fd, err := os.OpenFile(devPath, os.O_RDWR, fs.FileMode(os.O_RDWR))
 	if err != nil {
 		err = fmt.Errorf("open chip %v failed: %w", devPath, err)
@@ -84,12 +84,14 @@ func newEncoder(
 	return &revolutionPiEncoder{Named: conf.ResourceName().AsNamed(), pin: enc}, nil
 }
 
+// TODO implementing in https://viam.atlassian.net/browse/RSDK-7595
 func (enc *revolutionPiEncoder) Position(ctx context.Context, positionType encoder.PositionType,
 	extra map[string]interface{},
 ) (float64, encoder.PositionType, error) {
 	return 0, encoder.PositionTypeTicks, nil
 }
 
+// TODO implementing in https://viam.atlassian.net/browse/RSDK-7595
 func (enc *revolutionPiEncoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
 	return nil
 }
@@ -98,6 +100,7 @@ func (enc *revolutionPiEncoder) Properties(ctx context.Context, extra map[string
 	return encoder.Properties{TicksCountSupported: true, AngleDegreesSupported: false}, nil
 }
 
+// TODO implementing in https://viam.atlassian.net/browse/RSDK-7595
 func (enc *revolutionPiEncoder) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
 	resp := make(map[string]interface{})
 	return resp, nil

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -21,10 +21,10 @@ type revolutionPiEncoder struct {
 	pin *digitalInterrupt
 }
 
-// Model is the model triplet for the rev-pi board.
+// EncoderModel is the model triplet for the rev-pi board encoder.
 var EncoderModel = resource.NewModel("viam-labs", "kunbus", "revolutionpi-encoder")
 
-// EncoderConfig is the config for the rev-pi board.
+// EncoderConfig is the config for the rev-pi board encoder.
 type EncoderConfig struct {
 	resource.TriviallyValidateConfig
 	Name string `json:"name,omitempty"`
@@ -77,7 +77,9 @@ func newEncoder(
 	return &revolutionPiEncoder{pin: enc}, nil
 }
 
-func (enc *revolutionPiEncoder) Position(ctx context.Context, positionType encoder.PositionType, extra map[string]interface{}) (float64, encoder.PositionType, error) {
+func (enc *revolutionPiEncoder) Position(ctx context.Context, positionType encoder.PositionType,
+	extra map[string]interface{},
+) (float64, encoder.PositionType, error) {
 	return 0, encoder.PositionTypeTicks, nil
 }
 
@@ -90,7 +92,8 @@ func (enc *revolutionPiEncoder) Properties(ctx context.Context, extra map[string
 }
 
 func (enc *revolutionPiEncoder) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
-	return nil, nil
+	resp := make(map[string]interface{})
+	return resp, nil
 }
 
 func (enc *revolutionPiEncoder) Close(ctx context.Context) error {

--- a/revolutionpi/encoder.go
+++ b/revolutionpi/encoder.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+// Package revolutionpi implements the Revolution Pi board GPIO pins.
+package revolutionpi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"go.viam.com/rdk/components/encoder"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+)
+
+type revolutionPiEncoder struct {
+	resource.Named
+	resource.TriviallyReconfigurable
+	pin *digitalInterrupt
+}
+
+// Model is the model triplet for the rev-pi board.
+var EncoderModel = resource.NewModel("viam-labs", "kunbus", "revolutionpi-encoder")
+
+// // Config is the config for the rev-pi board.
+// type Config struct {
+// 	resource.TriviallyValidateConfig
+// 	Attributes utils.AttributeMap `json:"attributes,omitempty"`
+// }
+
+func init() {
+	resource.RegisterComponent(
+		encoder.API,
+		EncoderModel,
+		resource.Registration[encoder.Encoder, *Config]{Constructor: newEncoder})
+}
+
+func newEncoder(
+	ctx context.Context,
+	_ resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+) (encoder.Encoder, error) {
+	devPath := filepath.Join("/dev", "piControl0")
+	devPath = filepath.Clean(devPath)
+	fd, err := os.OpenFile(devPath, os.O_RDWR, fs.FileMode(os.O_RDWR))
+	if err != nil {
+		err = fmt.Errorf("open chip %v failed: %w", devPath, err)
+		return nil, err
+	}
+	gpioChip := gpioChip{dev: devPath, logger: logger, fileHandle: fd}
+
+	err = gpioChip.showDeviceList()
+	if err != nil {
+		return nil, err
+	}
+	name := "InputMode_5"
+	pin := SPIVariable{strVarName: char32(name)}
+	err = gpioChip.mapNameToAddress(&pin)
+	if err != nil {
+		return nil, err
+	}
+
+	enc, err := initializeDigitalInterrupt(pin, &gpioChip, true)
+	if err != nil {
+		return nil, err
+	}
+	if !enc.isEncoder {
+		return nil, errors.New("address is not configured as an encoder")
+	}
+	return &revolutionPiEncoder{pin: enc}, nil
+}
+
+func (enc *revolutionPiEncoder) Position(ctx context.Context, positionType encoder.PositionType, extra map[string]interface{}) (float64, encoder.PositionType, error) {
+	return 0, encoder.PositionTypeTicks, nil
+}
+
+func (enc *revolutionPiEncoder) ResetPosition(ctx context.Context, extra map[string]interface{}) error {
+	return nil
+}
+
+func (enc *revolutionPiEncoder) Properties(ctx context.Context, extra map[string]interface{}) (encoder.Properties, error) {
+	props := encoder.Properties{TicksCountSupported: true, AngleDegreesSupported: false}
+	return props, nil
+}
+
+func (enc revolutionPiEncoder) DoCommand(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (enc revolutionPiEncoder) Close(ctx context.Context) error {
+	return nil
+}

--- a/revolutionpi/gpio_chip.go
+++ b/revolutionpi/gpio_chip.go
@@ -74,7 +74,7 @@ func (g *gpioChip) GetDigitalInterrupt(pinName string) (*digitalInterrupt, error
 		return nil, err
 	}
 
-	return initializeDigitalInterrupt(pin, g)
+	return initializeDigitalInterrupt(pin, g, false)
 }
 
 func (g *gpioChip) mapNameToAddress(pin *SPIVariable) error {

--- a/revolutionpi/revolution_pi.go
+++ b/revolutionpi/revolution_pi.go
@@ -106,8 +106,7 @@ func (b *revolutionPiBoard) DigitalInterruptByName(name string) (board.DigitalIn
 		return nil, err
 	}
 	b.logger.Debugf("Interrupt Pin: %#v", interrupt)
-
-	return interrupt, nil
+	return &diWrapper{pin: interrupt}, nil
 }
 
 func (b *revolutionPiBoard) AnalogNames() []string {


### PR DESCRIPTION
first pr to add encoders to the revpi module. This PR adds the encoder model, initializes the encoder, and has placeholders for the encoder APIs. 

ticket: https://viam.atlassian.net/browse/RSDK-7596
